### PR TITLE
Null Pointer Exception on HTTP request with No Content in response and printResponse = true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.ohio.ais.rundeck</groupId>
     <artifactId>rundeck-http-plugin</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Perform HTTP requests with authentication as a Rundeck workflow step.</description>

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -580,21 +580,24 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable {
     private StringBuffer getPageContent(HttpResponse response) {
 
         BufferedReader rd = null;
-        try {
-            rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
+        HttpEntity reponseEntity = response.getEntity();
         StringBuffer result = new StringBuffer();
 
-        String line = "";
-        try {
-            while ((line = rd.readLine()) != null) {
-                result.append(line);
+        if ( reponseEntity != null ) {
+            try {
+                rd = new BufferedReader(new InputStreamReader(reponseEntity.getContent()));
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-        } catch (IOException e) {
-            e.printStackTrace();
+
+            String line = "";
+            try {
+                while ((line = rd.readLine()) != null) {
+                    result.append(line);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
 
         return result;

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowStepPluginTest.java
@@ -26,6 +26,7 @@ public class HttpWorkflowStepPluginTest {
     protected static final String REMOTE_OAUTH_EXPIRED_URL = "/oauth-expired";
     protected static final String ERROR_URL_500 = "/error500";
     protected static final String ERROR_URL_401 = "/error401";
+    protected static final String NO_CONTENT_URL = "/nocontent204";
     protected static final String OAUTH_CLIENT_MAP_KEY = OAuthClientTest.CLIENT_VALID + "@"
             + OAuthClientTest.BASE_URI + OAuthClientTest.ENDPOINT_TOKEN;
 
@@ -126,6 +127,11 @@ public class HttpWorkflowStepPluginTest {
             WireMock.stubFor(WireMock.request(method, WireMock.urlEqualTo(ERROR_URL_500))
                     .willReturn(WireMock.aResponse()
                             .withStatus(500)));
+
+            // 204 No Content
+            WireMock.stubFor(WireMock.request(method, WireMock.urlEqualTo(NO_CONTENT_URL))
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(204)));
         }
 
         // Simple bogus URL that yields a 404
@@ -299,6 +305,18 @@ public class HttpWorkflowStepPluginTest {
         Map<String, Object> options = getOAuthOptions("GET");
 
         options.put("remoteUrl", OAuthClientTest.BASE_URI + ERROR_URL_500);
+
+        this.plugin.executeStep(new PluginStepContextImpl(), options);
+    }
+
+    @Test
+    public void canPrintNoContent() throws StepException {
+        Map<String, Object> options = new HashMap<>();
+
+        options.put("remoteUrl", OAuthClientTest.BASE_URI + NO_CONTENT_URL);
+        options.put("method", "GET");
+        options.put("printResponse",true);
+        options.put("printResponseToFile",false);
 
         this.plugin.executeStep(new PluginStepContextImpl(), options);
     }


### PR DESCRIPTION
If we invoke an HTTP API that returns a 204 ( No Content ), but have enabled the "Print Response" option, the plugin fails with a Null Pointer Exception as follows:

```
Failed executing step plugin [edu.ohio.ais.rundeck.HttpWorkflowStepPlugin]: java.lang.NullPointerException
	at edu.ohio.ais.rundeck.HttpWorkflowStepPlugin.getPageContent(HttpWorkflowStepPlugin.java:584)
	at edu.ohio.ais.rundeck.HttpWorkflowStepPlugin.prettyPrint(HttpWorkflowStepPlugin.java:617)
	at edu.ohio.ais.rundeck.HttpWorkflowStepPlugin.doRequest(HttpWorkflowStepPlugin.java:287)
	at edu.ohio.ais.rundeck.HttpWorkflowStepPlugin.executeStep(HttpWorkflowStepPlugin.java:576)
	at com.dtolabs.rundeck.core.execution.workflow.steps.StepPluginAdapter.executeWorkflowStep(StepPluginAdapter.java:114)
	at com.dtolabs.rundeck.core.execution.ExecutionServiceImpl.executeStep(ExecutionServiceImpl.java:111)
	at com.dtolabs.rundeck.core.execution.workflow.BaseWorkflowExecutor.executeWFItem(BaseWorkflowExecutor.java:291)
	at com.dtolabs.rundeck.core.execution.workflow.BaseWorkflowExecutor.executeWorkflowStep(BaseWorkflowExecutor.java:687)
	at com.dtolabs.rundeck.core.execution.workflow.engine.StepCallable.apply(StepCallable.java:71)
	at com.dtolabs.rundeck.core.execution.workflow.engine.StepOperation.apply(StepOperation.java:73)
	at com.dtolabs.rundeck.core.execution.workflow.engine.StepOperation.apply(StepOperation.java:31)
	at com.dtolabs.rundeck.core.rules.WorkflowEngineOperationsProcessor.lambda$processRunnableOperations$1(WorkflowEngineOperationsProcessor.java:222)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
I have created a test for this, then implemented a fix.

I have also added a commit to close the HTTPResponse object ( and response entity ) as these were not being closed previously, which could lead to resource leaks.

Could these fixes be merged and a new release of the plugin created?

Many thanks
Dave