### PR TITLE
Change the plugin name to avoid clash with Ohioit version of this plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 sourceCompatibility = 1.8
 ext.rundeckPluginVersion = '1.2'
 ext.pluginClassNames='edu.ohio.ais.rundeck.HttpWorkflowStepPlugin'
-ext.pluginName = 'Http Step'
+ext.pluginName = 'Rundeck Http Step'
 ext.pluginDescription = 'A workflow plugin that makes HTTP requests'
 
 scmVersion {


### PR DESCRIPTION
I'd like to change the name of this plugin so that the artifact it generates for the repository doesn't clash with the Ohioit http step plugin.