### PR TITLE
RUN-1302: Add option to print HTTP response code and status

### DIFF
--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -127,6 +127,12 @@ public class HttpBuilder {
         try {
             response = this.getHttpClient(options).execute(request);
 
+            if(options.containsKey("printResponseCode") && Boolean.parseBoolean(options.get("printResponseCode").toString())) {
+
+                String responseCode = Integer.toString(response.getStatusLine().getStatusCode());
+                log.log(2, responseCode);
+            }
+
             //print the response content
             if(options.containsKey("printResponse") && Boolean.parseBoolean(options.get("printResponse").toString()) ||
                     options.containsKey("printResponseToFile") && Boolean.parseBoolean(options.get("printResponseToFile").toString())) {

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -129,8 +129,8 @@ public class HttpBuilder {
 
             if(options.containsKey("printResponseCode") && Boolean.parseBoolean(options.get("printResponseCode").toString())) {
 
-                String responseCode = Integer.toString(response.getStatusLine().getStatusCode());
-                log.log(2, responseCode);
+                String responseCode = response.getStatusLine().toString();
+                log.log(2, "Response Code: " + responseCode);
             }
 
             //print the response content

--- a/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
@@ -158,6 +158,13 @@ public class HttpDescription  implements Describable {
                         .renderingOption(StringRenderingConstants.GROUP_NAME,"Proxy Settings")
                         .required(false)
                         .build())
+                .property(PropertyBuilder.builder()
+                        .booleanType("printResponseCode")
+                        .title("Print Response Code?")
+                        .description("Set if the response code should be printed.")
+                        .defaultValue("false")
+                        .renderingOption(StringRenderingConstants.GROUP_NAME,"Print")
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
@@ -161,7 +161,7 @@ public class HttpDescription  implements Describable {
                 .property(PropertyBuilder.builder()
                         .booleanType("printResponseCode")
                         .title("Print Response Code?")
-                        .description("Set if the response code should be printed.")
+                        .description("Select to print the HTTP response code and status.")
                         .defaultValue("false")
                         .renderingOption(StringRenderingConstants.GROUP_NAME,"Print")
                         .build())

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
@@ -1,6 +1,8 @@
 package edu.ohio.ais.rundeck;
 
 import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.execution.ExecutionContext;
+import com.dtolabs.rundeck.core.execution.ExecutionLogger;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
@@ -17,8 +19,8 @@ import org.mockito.Mockito;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 public class HttpWorkflowNodeStepPluginTest {
     protected static final String REMOTE_URL = "/trigger";
@@ -154,10 +156,10 @@ public class HttpWorkflowNodeStepPluginTest {
         node = Mockito.mock(INodeEntry.class);
         pluginContext = Mockito.mock(PluginStepContext.class);
         pluginLogger = Mockito.mock(PluginLogger.class);
-        Mockito.when(pluginContext.getLogger()).thenReturn(pluginLogger);
+        when(pluginContext.getLogger()).thenReturn(pluginLogger);
 
         dataContext =new HashMap<>();
-        Mockito.when(pluginContext.getDataContext()).thenReturn(dataContext);
+        when(pluginContext.getDataContext()).thenReturn(dataContext);
 
     }
 
@@ -182,6 +184,7 @@ public class HttpWorkflowNodeStepPluginTest {
         options.put("remoteUrl", REMOTE_URL);
         options.put("method", "GET");
         options.put("authentication", HttpBuilder.AUTH_BASIC);
+        options.put("printResponseCode", "true");
 
         try {
             this.plugin.executeNodeStep(pluginContext, options, node );
@@ -232,6 +235,7 @@ public class HttpWorkflowNodeStepPluginTest {
         for(String method : HttpBuilder.HTTP_METHODS) {
             Map<String, Object> options = this.getBasicOptions(method);
             options.put("remoteUrl", OAuthClientTest.BASE_URI + REMOTE_BASIC_URL);
+            options.put("printResponseCode", "true");
 
             this.plugin.executeNodeStep(pluginContext, options, node );
         }
@@ -242,6 +246,7 @@ public class HttpWorkflowNodeStepPluginTest {
         Map<String, Object> options = new HashMap<>();
 
         options.put("remoteUrl", OAuthClientTest.BASE_URI + ERROR_URL_500);
+        options.put("printResponseCode", "true");
         options.put("method", "GET");
 
         this.plugin.executeNodeStep(pluginContext, options, node );

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowStepPluginTest.java
@@ -181,6 +181,7 @@ public class HttpWorkflowStepPluginTest {
         options.put("remoteUrl", REMOTE_URL);
         options.put("method", "GET");
         options.put("authentication", HttpBuilder.AUTH_BASIC);
+        options.put("printResponseCode", "true");
 
         try {
             this.plugin.executeStep(pluginContext, options);
@@ -231,6 +232,7 @@ public class HttpWorkflowStepPluginTest {
         for(String method : HttpBuilder.HTTP_METHODS) {
             Map<String, Object> options = this.getBasicOptions(method);
             options.put("remoteUrl", OAuthClientTest.BASE_URI + REMOTE_BASIC_URL);
+            options.put("printResponseCode", "true");
 
             this.plugin.executeStep(pluginContext, options);
         }
@@ -242,6 +244,7 @@ public class HttpWorkflowStepPluginTest {
 
         options.put("remoteUrl", OAuthClientTest.BASE_URI + ERROR_URL_500);
         options.put("method", "GET");
+        options.put("printResponseCode", "true");
 
         this.plugin.executeStep(pluginContext, options);
     }


### PR DESCRIPTION
This gives users the option to print the HTTP response code and status.  This is valuable for building job-logic based on the HTTP status code.

Provide **code review** and update unit tests.