### PR TITLE
RSE-852 Fix: Visible Error in HttpWorkflowNodeStepPlugin Output

### DIFF
--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -144,7 +144,11 @@ public class HttpBuilder {
             if(options.containsKey("printResponseToFile") && Boolean.parseBoolean(options.get("printResponseToFile").toString())){
                 File file = new File(options.get("file").toString());
                 BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-                if( output != null ) writer.write (output);
+                if( output == null ){
+                    output = this.prettyPrint(response);
+                }
+
+                writer.write (output);
 
                 //Close writer
                 writer.close();

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -249,10 +249,7 @@ public class HttpBuilder {
     }
 
     private String getOutputForResponse(String printer){
-        if( !printer.isEmpty() ){
-            return printer;
-        }
-        return "";
+        return !printer.isEmpty() ? printer : "";
     }
 
     private StringBuffer getPageContent(HttpResponse response) {

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -125,7 +125,7 @@ public class HttpBuilder {
             throw new StepException("Unable to complete request after maximum number of attempts.", StepFailureReason.IOFailure);
         }
         CloseableHttpResponse response = null;
-        String output = null;
+        String output = "";
         try {
             response = this.getHttpClient(options).execute(request);
 
@@ -136,7 +136,7 @@ public class HttpBuilder {
 
             //print the response content
             if(options.containsKey("printResponse") && Boolean.parseBoolean(options.get("printResponse").toString())) {
-                output = this.prettyPrint(response);
+                output = getOutputForResponse(this.prettyPrint(response));
                 //print response
                 log.log(2, output);
             }
@@ -144,8 +144,8 @@ public class HttpBuilder {
             if(options.containsKey("printResponseToFile") && Boolean.parseBoolean(options.get("printResponseToFile").toString())){
                 File file = new File(options.get("file").toString());
                 BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-                if( output == null ){
-                    output = this.prettyPrint(response);
+                if( output.isEmpty() ){
+                    output = getOutputForResponse(this.prettyPrint(response));
                 }
 
                 writer.write (output);
@@ -246,6 +246,13 @@ public class HttpBuilder {
                 }
             }
         }
+    }
+
+    private String getOutputForResponse(String printer){
+        if( !printer.isEmpty() ){
+            return printer;
+        }
+        return "";
     }
 
     private StringBuffer getPageContent(HttpResponse response) {

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -125,6 +125,7 @@ public class HttpBuilder {
             throw new StepException("Unable to complete request after maximum number of attempts.", StepFailureReason.IOFailure);
         }
         CloseableHttpResponse response = null;
+        String output = null;
         try {
             response = this.getHttpClient(options).execute(request);
 
@@ -135,16 +136,15 @@ public class HttpBuilder {
 
             //print the response content
             if(options.containsKey("printResponse") && Boolean.parseBoolean(options.get("printResponse").toString())) {
-                String output = this.prettyPrint(response);
+                output = this.prettyPrint(response);
                 //print response
                 log.log(2, output);
             }
 
             if(options.containsKey("printResponseToFile") && Boolean.parseBoolean(options.get("printResponseToFile").toString())){
-                String output = this.prettyPrint(response);
                 File file = new File(options.get("file").toString());
                 BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-                writer.write (output);
+                if( output != null ) writer.write (output);
 
                 //Close writer
                 writer.close();

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
@@ -383,4 +383,19 @@ public class HttpWorkflowNodeStepPluginTest {
         this.plugin.executeNodeStep(pluginContext, options, node );
         assertNotNull(readFileAsString(testResource.toString()));
     }
+
+    @Test
+    public void canPrintContentToFileIfPrintResponseIsFalse() throws NodeStepException, IOException {
+        Map<String, Object> options = new HashMap<>();
+
+        options.put("remoteUrl", OAuthClientTest.BASE_URI + NO_CONTENT_URL);
+        options.put("method", "GET");
+        options.put("printResponse",false);
+        options.put("printResponseToFile",true);
+        options.put("file", testResource);
+
+        assertNotNull(Paths.get(testResource.toString()));
+        this.plugin.executeNodeStep(pluginContext, options, node );
+        assertNotNull(readFileAsString(testResource.toString()));
+    }
 }

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
@@ -11,11 +11,18 @@ import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import edu.ohio.ais.rundeck.util.OAuthClientTest;
+import org.apache.tools.ant.util.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,6 +53,8 @@ public class HttpWorkflowNodeStepPluginTest {
     protected PluginStepContext pluginContext;
     protected PluginLogger pluginLogger;
     protected INodeEntry node;
+    protected File resourcePath = new File("src" + File.separator + "test" + File.separator + "resources");
+    protected File testResource = new File(resourcePath + File.separator + "example.json");
 
     /**
      * Setup options for simple execution for the given method.
@@ -92,8 +101,21 @@ public class HttpWorkflowNodeStepPluginTest {
         return options;
     }
 
+    private static String readFileAsString(String filePath) throws IOException {
+        Path path = Paths.get(filePath);
+        byte[] bytes = Files.readAllBytes(path);
+        return new String(bytes);
+    }
+
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(18089);
+
+    @After
+    public void tearDown(){
+        if( Files.exists(this.testResource.toPath()) ){
+            FileUtils.delete(this.testResource);
+        }
+    }
 
     @Before
     public void setUp() {
@@ -345,5 +367,20 @@ public class HttpWorkflowNodeStepPluginTest {
         options.put("printResponseToFile",false);
 
         this.plugin.executeNodeStep(pluginContext, options, node );
+    }
+
+    @Test
+    public void canPrintContentToFile() throws NodeStepException, IOException {
+        Map<String, Object> options = new HashMap<>();
+
+        options.put("remoteUrl", OAuthClientTest.BASE_URI + NO_CONTENT_URL);
+        options.put("method", "GET");
+        options.put("printResponse",true);
+        options.put("printResponseToFile",true);
+        options.put("file", testResource);
+
+        assertNotNull(Paths.get(testResource.toString()));
+        this.plugin.executeNodeStep(pluginContext, options, node );
+        assertNotNull(readFileAsString(testResource.toString()));
     }
 }


### PR DESCRIPTION
# RSE-852 Fix: Visible Error in HttpWorkflowNodeStepPlugin Output
When we api response and attempt to write the output in job log and create a file in server's filesystem at the same time, we get a visible error stack trace in job log.

# The Error
The execution attempt to re-use a Stream twice to print the result and build the file.

# The Fix
Allocate the "pretty printed" string in memory and re use it instead of reusing a stream.