### PR TITLE
Remove use of yamlbeans, use snakeyaml instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 
     pluginLibs group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
     pluginLibs group: 'com.google.code.gson', name: 'gson', version:'2.10.1'
-    pluginLibs group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version:'1.13'
 
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone', version:'2.23.2'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -6,7 +6,6 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.storage.ResourceMeta;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
-import com.esotericsoftware.yamlbeans.YamlReader;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
@@ -28,6 +27,8 @@ import org.apache.http.util.EntityUtils;
 import org.dom4j.DocumentHelper;
 import org.dom4j.io.OutputFormat;
 import org.dom4j.io.XMLWriter;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.io.*;
 import java.security.GeneralSecurityException;
@@ -438,9 +439,8 @@ public class HttpBuilder {
             map = new HashMap<>();
             Object object = null;
             try {
-                YamlReader reader = new YamlReader(headers);
-                object = reader.read();
-                map = (Map<String,String>) object;
+                Yaml yaml = new Yaml(new Constructor(Map.class));
+                map = yaml.load(headers);
             } catch (Exception e) {
                 map = null;
             }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -27,8 +27,10 @@ import org.apache.http.util.EntityUtils;
 import org.dom4j.DocumentHelper;
 import org.dom4j.io.OutputFormat;
 import org.dom4j.io.XMLWriter;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.*;
 import java.security.GeneralSecurityException;
@@ -439,7 +441,7 @@ public class HttpBuilder {
             map = new HashMap<>();
             Object object = null;
             try {
-                Yaml yaml = new Yaml(new Constructor(Map.class));
+                Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
                 map = yaml.load(headers);
             } catch (Exception e) {
                 map = null;


### PR DESCRIPTION
move to using snakeyaml to avoid CVE-2023-24621.

also updated rundeck-core version to a more up to date version. cant go to 5.0 series w/o java upgrade