### PR TITLE
RUN-2412: Plugin property mapping

### DIFF
--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -110,19 +110,18 @@ public class HttpBuilder {
             httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
             httpClientBuilder.setSSLContext(sslContextBuilder.build());
         }
-        if(options.containsKey("proxySettings") && Boolean.parseBoolean(options.get("proxySettings").toString())){
-            log.log(5, "proxy IP set in job: " + options.get("proxyIP").toString());
-
-            HttpHost proxy = new HttpHost(options.get("proxyIP").toString(), Integer.valueOf((String)options.get("proxyPort")), "http");
-            httpClientBuilder.setProxy(proxy);
-        }
-
         if(options.get("useSystemProxySettings").equals("true")) {
 
             log.log(5, "Using proxy settings set on system");
 
             httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
 
+        }
+        if(options.containsKey("proxySettings") && Boolean.parseBoolean(options.get("proxySettings").toString())){
+            log.log(5, "proxy IP set in job: " + options.get("proxyIP").toString());
+
+            HttpHost proxy = new HttpHost(options.get("proxyIP").toString(), Integer.valueOf((String)options.get("proxyPort")), "http");
+            httpClientBuilder.setProxy(proxy);
         }
 
         return httpClientBuilder.build();

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -464,10 +464,10 @@ public class HttpBuilder {
         }
     }
 
-    static void propertyResolver(String property, Map<String,Object> Configuration, PluginStepContext context, String SERVICE_PROVIDER_NAME) {
+    static void propertyResolver(String pluginType, String property, Map<String,Object> Configuration, PluginStepContext context, String SERVICE_PROVIDER_NAME) {
 
-        String projectPrefix = "project.plugin.WorkflowNodeStep." + SERVICE_PROVIDER_NAME + ".";
-        String frameworkPrefix = "framework.plugin.WorkflowNodeStep" + SERVICE_PROVIDER_NAME + ".";
+        String projectPrefix = "project.plugin." + pluginType + "." + SERVICE_PROVIDER_NAME + ".";
+        String frameworkPrefix = "framework.plugin." + pluginType + "." + SERVICE_PROVIDER_NAME + ".";
 
         Map<String,String> projectProperties = context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()).getProperties();
         IPropertyLookup frameworkProperties = context.getFramework().getPropertyLookup();

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -110,7 +110,7 @@ public class HttpBuilder {
             httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
             httpClientBuilder.setSSLContext(sslContextBuilder.build());
         }
-        if(options.get("useSystemProxySettings").equals("true")) {
+        if(options.get("useSystemProxySettings").equals("true") && !Boolean.parseBoolean(options.get("proxySettings").toString())) {
 
             log.log(5, "Using proxy settings set on system");
 

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -23,6 +23,7 @@ import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
 import org.dom4j.DocumentHelper;
@@ -34,6 +35,7 @@ import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.*;
+import java.net.ProxySelector;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -109,11 +111,16 @@ public class HttpBuilder {
             httpClientBuilder.setSSLContext(sslContextBuilder.build());
         }
         if(options.containsKey("proxySettings") && Boolean.parseBoolean(options.get("proxySettings").toString())){
-            log.log(5, "using proxy IP: " + options.get("proxyIP").toString());
-            log.log(5, "using proxy Port: " + options.get("proxyPort").toString());
+            log.log(5, "proxy IP set in job: " + options.get("proxyIP").toString());
 
             HttpHost proxy = new HttpHost(options.get("proxyIP").toString(), Integer.valueOf((String)options.get("proxyPort")), "http");
             httpClientBuilder.setProxy(proxy);
+        }
+
+        if(options.get("useSystemProxySettings").equals("true")) {
+
+            httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
+
         }
 
         return httpClientBuilder.build();

--- a/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpBuilder.java
@@ -119,6 +119,8 @@ public class HttpBuilder {
 
         if(options.get("useSystemProxySettings").equals("true")) {
 
+            log.log(5, "Using proxy settings set on system");
+
             httpClientBuilder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
 
         }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
@@ -165,8 +165,6 @@ public class HttpDescription  implements Describable {
                         .defaultValue("false")
                         .renderingOption(StringRenderingConstants.GROUP_NAME,"Print")
                         .build())
-                .mapping("proxyIP","project.plugin.WorkflowNodeStep.HttpWorkflowNodeStepPlugin.proxyIP")
-
                 .build();
     }
 }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
@@ -2,6 +2,7 @@ package edu.ohio.ais.rundeck;
 
 import com.dtolabs.rundeck.core.plugins.configuration.Describable;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope;
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder;
@@ -164,6 +165,12 @@ public class HttpDescription  implements Describable {
                         .description("Select to print the HTTP response code and status.")
                         .defaultValue("false")
                         .renderingOption(StringRenderingConstants.GROUP_NAME,"Print")
+                        .build())
+                .property(PropertyBuilder.builder()
+                        .booleanType("useSystemProxySettings")
+                        .description("Choose whether to use proxy settings set on the JVM.")
+                        .defaultValue("false")
+                        .scope(PropertyScope.Project)
                         .build())
                 .build();
     }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpDescription.java
@@ -165,6 +165,8 @@ public class HttpDescription  implements Describable {
                         .defaultValue("false")
                         .renderingOption(StringRenderingConstants.GROUP_NAME,"Print")
                         .build())
+                .mapping("proxyIP","project.plugin.WorkflowNodeStep.HttpWorkflowNodeStepPlugin.proxyIP")
+
                 .build();
     }
 }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
@@ -65,7 +65,7 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
 
         Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
         description.getProperties().forEach(prop->
-            propertyResolver(prop.getName(), configuration, context, SERVICE_PROVIDER_NAME)
+            propertyResolver("WorlflowNodeStep", prop.getName(), configuration, context, SERVICE_PROVIDER_NAME)
         );
 
         // Parse out the options

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
@@ -29,6 +29,8 @@ import org.apache.http.entity.ByteArrayEntity;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 
+import static edu.ohio.ais.rundeck.HttpBuilder.propertyResolver;
+
 @Plugin(name = HttpWorkflowNodeStepPlugin.SERVICE_PROVIDER_NAME, service = ServiceNameConstants.WorkflowNodeStep)
 public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, ProxySecretBundleCreator {
     public static final String SERVICE_PROVIDER_NAME = "edu.ohio.ais.rundeck.HttpWorkflowNodeStepPlugin";
@@ -43,13 +45,6 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
      * request for the URL, not OAuth authentication.
      */
     public static final Integer DEFAULT_TIMEOUT = 30*1000;
-
-//    @PluginProperty(
-//            title = "Proxy URL",
-//            description = "HTTP URL to which to make the request.",
-//            required = true
-//    )
-//    String proxyURL;
 
     /**
      * Synchronized map of all existing OAuth clients. This is indexed by
@@ -70,13 +65,8 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
 
         Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
         description.getProperties().forEach(prop->
-            propertyResolver(prop.getName(), configuration, context)
+            propertyResolver(prop.getName(), configuration, context, SERVICE_PROVIDER_NAME)
         );
-//        propertyResolver("proxyIP", configuration, context);
-//        propertyResolver("proxyPort", configuration, context);
-
-        System.out.println("post-resolver proxyIp: " + configuration.get("proxyIP"));
-//        System.out.println("proxySettings: " + configuration.get("proxySettings"));
 
         // Parse out the options
         String remoteUrl = configuration.containsKey("remoteUrl") ? configuration.get("remoteUrl").toString() : null;
@@ -165,26 +155,6 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
     @Override
     public List<String> listSecretsPathWorkflowNodeStep(ExecutionContext context, INodeEntry node, Map<String, Object> configuration) {
         return SecretBundleUtil.getListSecrets(configuration);
-    }
-
-    void propertyResolver(String property, Map<String,Object> Configuration, PluginStepContext context) {
-
-        String projectPrefix = "project.plugin.WorkflowNodeStep." + SERVICE_PROVIDER_NAME + ".";
-        String frameworkPrefix = "framework.plugin.WorkflowNodeStep" + SERVICE_PROVIDER_NAME + ".";
-
-        Map<String,String> projectProperties = context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()).getProperties();
-        IPropertyLookup frameworkProperties = context.getFramework().getPropertyLookup();
-
-        if(!Configuration.containsKey(property) && projectProperties.containsKey(projectPrefix + property)) {
-
-            Configuration.put(property, projectProperties.get(projectPrefix + property));
-
-        } else if (!Configuration.containsKey(property) && frameworkProperties.hasProperty(frameworkPrefix + property)) {
-
-            Configuration.put(property, frameworkProperties.getProperty(frameworkPrefix + property));
-
-        }
-        System.out.println("resolver: " + property + Configuration.get(property));
     }
 
 }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
@@ -65,7 +65,7 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
 
         Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
         description.getProperties().forEach(prop->
-            propertyResolver("WorlflowNodeStep", prop.getName(), configuration, context, SERVICE_PROVIDER_NAME)
+            propertyResolver("WorkflowNodeStep", prop.getName(), configuration, context, SERVICE_PROVIDER_NAME)
         );
 
         // Parse out the options

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPlugin.java
@@ -30,7 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.*;
 
 @Plugin(name = HttpWorkflowNodeStepPlugin.SERVICE_PROVIDER_NAME, service = ServiceNameConstants.WorkflowNodeStep)
-public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, ProxySecretBundleCreator, DescriptionBuilder.Collaborator {
+public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, ProxySecretBundleCreator {
     public static final String SERVICE_PROVIDER_NAME = "edu.ohio.ais.rundeck.HttpWorkflowNodeStepPlugin";
 
     /**
@@ -68,9 +68,11 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
     public void executeNodeStep(PluginStepContext context, Map<String, Object> configuration, INodeEntry entry) throws NodeStepException {
         PluginLogger log = context.getLogger();
 
-        System.out.println("pre-resolver proxyIp: " + configuration.get("proxyIP"));
-//        propertyResolver("proxySettings", configuration, context);
-        propertyResolver("proxyIP", configuration, context);
+        Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
+        description.getProperties().forEach(prop->
+            propertyResolver(prop.getName(), configuration, context)
+        );
+//        propertyResolver("proxyIP", configuration, context);
 //        propertyResolver("proxyPort", configuration, context);
 
         System.out.println("post-resolver proxyIp: " + configuration.get("proxyIP"));
@@ -167,7 +169,7 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
 
     void propertyResolver(String property, Map<String,Object> Configuration, PluginStepContext context) {
 
-        String projectPrefix = "project.plugin.WorkflowNodeStep." + "HttpWorkflowNodeStepPlugin" + ".";
+        String projectPrefix = "project.plugin.WorkflowNodeStep." + SERVICE_PROVIDER_NAME + ".";
         String frameworkPrefix = "framework.plugin.WorkflowNodeStep" + SERVICE_PROVIDER_NAME + ".";
 
         Map<String,String> projectProperties = context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()).getProperties();
@@ -182,11 +184,7 @@ public class HttpWorkflowNodeStepPlugin implements NodeStepPlugin, Describable, 
             Configuration.put(property, frameworkProperties.getProperty(frameworkPrefix + property));
 
         }
-        System.out.println("resolver: " + Configuration.get(property));
+        System.out.println("resolver: " + property + Configuration.get(property));
     }
 
-    @Override
-    public void buildWith(DescriptionBuilder descriptionBuilder) {
-        descriptionBuilder.mapping("proxyIP", "project.plugin.WorkflowNodeStep.HTTPRequest.proxyIP");
-    }
 }

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -73,7 +73,7 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable, ProxySec
 
         Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
         description.getProperties().forEach(prop->
-                propertyResolver(prop.getName(), options, pluginStepContext, SERVICE_PROVIDER_NAME)
+                propertyResolver("WorflowStep",prop.getName(), options, pluginStepContext, SERVICE_PROVIDER_NAME)
         );
 
         // Parse out the options

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -23,6 +23,8 @@ import org.apache.http.entity.ByteArrayEntity;
 import java.io.*;
 import java.util.*;
 
+import static edu.ohio.ais.rundeck.HttpBuilder.propertyResolver;
+
 
 /**
  * Main implementation of the plugin. This will handle fetching
@@ -68,6 +70,11 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable, ProxySec
     @Override
     public void executeStep(PluginStepContext pluginStepContext, Map<String, Object> options) throws StepException {
         PluginLogger log = pluginStepContext.getLogger();
+
+        Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
+        description.getProperties().forEach(prop->
+                propertyResolver(prop.getName(), options, pluginStepContext, SERVICE_PROVIDER_NAME)
+        );
 
         // Parse out the options
         String remoteUrl = options.containsKey("remoteUrl") ? options.get("remoteUrl").toString() : null;

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -73,7 +73,7 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable, ProxySec
 
         Description description = new HttpDescription(SERVICE_PROVIDER_NAME, "HTTP Request Node Step", "Performs an HTTP request with or without authentication (per node)").getDescription();
         description.getProperties().forEach(prop->
-                propertyResolver("WorflowStep",prop.getName(), options, pluginStepContext, SERVICE_PROVIDER_NAME)
+                propertyResolver("WorkflowStep",prop.getName(), options, pluginStepContext, SERVICE_PROVIDER_NAME)
         );
 
         // Parse out the options

--- a/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
+++ b/src/test/java/edu/ohio/ais/rundeck/HttpWorkflowNodeStepPluginTest.java
@@ -1,11 +1,15 @@
 package edu.ohio.ais.rundeck;
 
+import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.common.FrameworkProject;
+import com.dtolabs.rundeck.core.common.FrameworkProjectMgr;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionLogger;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
+import com.dtolabs.rundeck.core.utils.IPropertyLookup;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -27,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 public class HttpWorkflowNodeStepPluginTest {
@@ -175,6 +180,20 @@ public class HttpWorkflowNodeStepPluginTest {
         when(executionContext.getExecutionLogger()).thenReturn(pluginLogger);
         when(pluginContext.getLogger()).thenReturn(pluginLogger);
         when(pluginContext.getExecutionContext()).thenReturn(executionContext);
+
+        // Mock the necessary objects
+        Framework framework = Mockito.mock(Framework.class);
+        FrameworkProjectMgr frameworkProjectMgr = Mockito.mock(FrameworkProjectMgr.class);
+        FrameworkProject frameworkProject = Mockito.mock(FrameworkProject.class);
+        IPropertyLookup frameworkProperties = Mockito.mock(IPropertyLookup.class);
+
+        // Mock the interactions
+        when(pluginContext.getFramework()).thenReturn(framework);
+        when(framework.getFrameworkProjectMgr()).thenReturn(frameworkProjectMgr);
+        when(frameworkProjectMgr.getFrameworkProject(anyString())).thenReturn(frameworkProject);
+        when(frameworkProject.getProperties()).thenReturn(new HashMap<String, String>());
+        when(framework.getPropertyLookup()).thenReturn(frameworkProperties);
+        when(frameworkProperties.hasProperty(anyString())).thenReturn(true);
 
         dataContext =new HashMap<>();
         when(pluginContext.getDataContext()).thenReturn(dataContext);


### PR DESCRIPTION
Two enhancements:
1. `propertyResolver` added so that properties set on the project/framework level are retrieved
2.  a new property can be set on project/framework level to force plugin to use proxy-settings set on the JVM (see comment below)